### PR TITLE
container(imagefactory): Fix ARG syntax

### DIFF
--- a/iso/empanadas/Containerfile.imagefactory
+++ b/iso/empanadas/Containerfile.imagefactory
@@ -57,7 +57,7 @@ RUN rm -rf /etc/yum.repos.d/*.repo /get_arch
 
 RUN pip install awscli
 
-ARG BRANCH r9
+ARG BRANCH=r9
 RUN git clone https://git.resf.org/sig_core/kickstarts.git --branch $BRANCH /kickstarts
 
 RUN pip install 'git+https://git.resf.org/sig_core/toolkit.git@devel#egg=empanadas&subdirectory=iso/empanadas'


### PR DESCRIPTION
Continerfile.imagefactory was missing an equal sign ('=') for an ARG default value. This prevented the container image build from completing a git clone successfully.